### PR TITLE
Testcase demonstrating return value of pointer-to-struct in static memory

### DIFF
--- a/test/clj_native/test/test_lib.c
+++ b/test/clj_native/test/test_lib.c
@@ -46,3 +46,17 @@ EXPORT void and3_buf(bool x, bool y, bool *z, int n, NBuf *pb) {
         *p++ = i;
     }
 }
+
+typedef struct {
+    int x;
+    int y;
+    const char * name;
+} Point;
+
+EXPORT Point *static_point(int x, int y) {
+    static Point point;
+    point.x = x;
+    point.y = y;
+    point.name = "foo";
+    return &point;
+}

--- a/test/clj_native/test/test_lib.clj
+++ b/test/clj_native/test/test_lib.clj
@@ -13,12 +13,17 @@
   (:structs
    (n-buf
     :n int
-    :buf void*))
+    :buf void*)
+   (point
+    :x int
+    :y int
+    :name constchar*))
   (:functions
    (mul [int int] int)
    (and2 [byte byte] byte)
    (and3 [byte byte byte*] void)
-   (and3_buf [byte byte byte* int n-buf*] void)))
+   (and3_buf [byte byte byte* int n-buf*] void)
+   (static_point [int int] point*)))
 
 (println "NOTE: Testing assumes a built test/clj_native/test/test_lib library")
 (System/setProperty "jna.library.path" "./test/clj_native/test")
@@ -64,4 +69,21 @@
        1 1 1 4
        0 0 0 3
        ))
+
+;; This was motivated by the Pm_GetDeviceInfo function from Portmidi,
+;; which has the signature:
+;;
+;; PMEXPORT const PmDeviceInfo* Pm_GetDeviceInfo( PmDeviceID id );
+;;
+;; The memory pointed to is owned by Portmidi and is not to be
+;; freed. A static variable has this property, so is a similar
+;; use-case.
+(deftest test-point
+  (are [x y x' y'] (let [thepoint (static_point x y)]
+                     (and
+                      (= x' (.x thepoint))
+                      (= y' (.y thepoint))
+                      (= "foo" (.name thepoint))))
+       1 2 1 2
+       -1 -4 -1 -4))
 


### PR DESCRIPTION
This testcase exemplifies how to solve a problem I had been having with a function from Portmidi.
You can see further discussion about it at: https://groups.google.com/d/topic/overtone/U43eDb485aQ/discussion

The fact that the struct contains a further pointer (the const char _) had been tripping me up -- if you specify `char_`in the struct declaration in defclib, it breaks; you *need*`constchar*` instead.
